### PR TITLE
Integrate changes from marsv024

### DIFF
--- a/manpages/pdf2archive.1
+++ b/manpages/pdf2archive.1
@@ -1,0 +1,138 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "PDF2ARCHIVE" "1" "March 2018" "" ""
+.
+.SH "NAME"
+\fBpdf2archive\fR \- a simple Ghostscript\-based PDF to PDF/A\-1B converter
+.
+.SH "SYNOPSIS"
+\fBpdf2archive\fR [\fIoptions\fR] \fIinput\.pdf\fR [\fIoutput\.pdf\fR]
+.
+.SH "DESCRIPTION"
+\fBpdf2archive\fR is a Bash program that converts a PDF to the PDF/A\-1B format\. The processing is done through Ghostscript, and the optional validation of the resulting document is carried out via VeraPDF\.
+.
+.SH "OPTIONS"
+.
+.SS "GENERAL OPTIONS"
+.
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Show the help\.
+.
+.TP
+\fB\-\-debug\fR
+Write additional debug information on screen\.
+.
+.TP
+\fB\-v\fR, \fB\-\-version\fR
+Show the program version\.
+.
+.SS "CONVERSION OPTIONS"
+.
+.TP
+\fB\-\-quality\fR=\fIvalue\fR
+Set the quality of the output when downsampling\. The possible values are \fIhigh\fR, \fImedium\fR and \fIlow\fR, where \fIhigh\fR gives the highest output quality\. By specifying no option, no additional downsampling is done\.
+.
+.TP
+\fB\-\-title\fR=\fIvalue\fR
+Title of the resulting PDF/A file\.
+.
+.TP
+\fB\-\-author\fR=\fIvalue\fR
+Author of the resulting PDF/A file\.
+.
+.TP
+\fB\-\-subject\fR=\fIvalue\fR
+Subject of the resulting PDF/A file\.
+.
+.TP
+\fB\-\-keywords\fR=\fIvalue\fR
+Comma\-separated keywords of the resulting PDF/A file\.
+.
+.TP
+\fB\-\-cleanmetadata\fR
+Clean all the standard metadata fields, except the ones specified via the command line options\.
+.
+.SS "VALIDATION OPTIONS"
+.
+.TP
+\fB\-\-validate\fR
+Validate the resulting file\. The validation is done with VeraPDF, you need a working Java installation\.
+.
+.SH "EXAMPLES"
+Convert input\.pdf in PDF/A\-1B format; the output is input\-PDFA\.pdf:
+.
+.IP "" 4
+.
+.nf
+
+pdf2archive input\.pdf
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Convert input\.pdf in PDF/A\-1B format; the output is output\.pdf:
+.
+.IP "" 4
+.
+.nf
+
+pdf2archive input\.pdf output\.pdf
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Convert input\.pdf in PDF/A\-1B format and perform a high\-quality compression:
+.
+.IP "" 4
+.
+.nf
+
+pdf2archive \-\-quality=high input\.pdf
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Convert input\.pdf in PDF/A\-1B format and specify the document title:
+.
+.IP "" 4
+.
+.nf
+
+pdf2archive \-\-title="Title of your nice document" input\.pdf
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Convert input\.pdf in PDF/A\-1B format and validate the result:
+.
+.IP "" 4
+.
+.nf
+
+pdf2archive \-\-validate input\.pdf
+.
+.fi
+.
+.IP "" 0
+.
+.SH "VERSION"
+This document was last revised for \fBpdf2archive\fR version 0\.3\.2\.
+.
+.SH "SEE ALSO"
+gs(1)
+.
+.SH "AUTHORS"
+(C) 2017\-2018 Matteo Seclì
+.
+.SH "BUGS"
+Please report any issue on GitHub\'s issue tracker \fIhttps://github\.com/matteosecli/pdf2archive/issues\fR\.

--- a/pdf2archive
+++ b/pdf2archive
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# PDF2ARCHIVE 0.3.2
+# PDF2ARCHIVE 0.4-alpha
 # (C) 2018 Matteo Seclì <secli.matteo@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -18,7 +18,8 @@
 
 
 #=====# INITIALIZE VARIABLES #=====#
-VERSION="0.3.2"
+unset CDPATH
+VERSION="0.4-alpha"
 INPUT=""
 OUTPUT=""
 QUALITYOPTS=""
@@ -26,8 +27,10 @@ DEBUG=false
 VALIDATE=false
 MSGOPTS="-dQUIET -sstdout=/dev/null"
 VERAMSGOPTS=""
+GSBIN="gs"
 #ERROPTS="2>/dev/null"
 
+# TODO: REPLACE == WITH = FOR COMPATIBILITY?
 
 #=====# HELP FUNCTION #=====#
 help()
@@ -76,6 +79,7 @@ OPTIONS:
   --validate          Validate  the resulting file. The  validation is done with
                       VeraPDF, you need a working Java installation.
   --debug             Write additional debug information on screen
+  --gspath=<value>    Optional path to ghostscript binary. Example /usr/bin/gs
   -v, --version       Show the program version
 
 LICENSE:
@@ -83,6 +87,199 @@ LICENSE:
 
 AUTHORS:
   (C) 2017-2018 Matteo Seclì"
+}
+
+
+#=====# FIND SOURCE PATH FUNCTION #=====#
+get_source_path() {
+    # Reference: https://stackoverflow.com/a/246128
+    # See also: https://gist.github.com/tvlooy/cbfbdb111a4ebad8b93e
+    SOURCE="${BASH_SOURCE[0]}"
+    while [ -h "$SOURCE" ]; do
+        SOURCEDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+        SOURCE="$(readlink "$SOURCE")"
+        # Here we cannot avoid [[ ]] because we need pattern matching
+        # Any POSIX-friendly idea?
+        [[ $SOURCE != /* ]] && SOURCE="$SOURCEDIR/$SOURCE"
+    done
+    SOURCEDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    # Escape to actually use it to call a binary
+    #SOURCEDIR=$(printf '%q' "$SOURCEDIR")
+    # Fallback to current dir if things go wrong; add "/"
+    if [ -z "$SOURCEDIR" ]; then
+        SOURCEDIR="./"
+    else
+        SOURCEDIR="$SOURCEDIR/"
+    fi
+    #eval $1=$SOURCEDIR
+}
+
+
+#=====# INSTALL FUNCTION #=====#
+install() {
+    if [ "$(which tar)" == "" ]; then
+      echo "  ERROR: tar binary not found!"
+      exit
+    fi
+    echo "=== Welcome to the installer of PDF2ARCHIVE ==="
+    INSTALLPREFIX="$1"
+    # Use default values if empty
+    if [ -z "$INSTALLPREFIX" ]; then
+        if [ -w "/usr/local/opt" ] || [ "$UID" -eq 0 ]; then
+            INSTALLPREFIX="/usr/local/opt"
+        else
+            INSTALLPREFIX="~/.local/opt"
+        fi
+        echo "  No installation prefix given, defaulting to '$INSTALLPREFIX'"
+    fi
+    # Choose where to put the symlinks
+    if [ -w "/usr/local/bin" ] || [ "$UID" -eq 0 ]; then
+        INSTALLBIN="/usr/local/bin"
+    else
+        INSTALLBIN="~/.local/bin"
+    fi
+    echo "  The binaries' symlinks will be installed in '$INSTALLBIN'"
+    # Choose where to put the manpage
+    if [ -w "/usr/local/share/man" ] || [ "$UID" -eq 0 ]; then
+        INSTALLMAN="/usr/local/share/man/man1"
+    else
+        INSTALLMAN="~/.local/share/man/man1"
+    fi
+    echo "  The manpages will be installed in '$INSTALLMAN'"
+    # Do the path expansion
+    #INSTALLPREFIX="`eval echo ${INSTALLPREFIX//>}`"
+    INSTALLPREFIX="$(cd "$INSTALLPREFIX" 2> /dev/null && pwd -P)"
+    INSTALLBIN="$(cd "$INSTALLBIN" 2> /dev/null && pwd -P)"
+    INSTALLMAN="$(cd "$INSTALLMAN" 2> /dev/null && pwd -P)"
+    [ -z "$INSTALLPREFIX" ] && { echo "  Something with the prefix path went wrong, aborting..."; exit; }
+    [ -z "$INSTALLBIN" ] && { echo "  Something with the binaries directory went wrong, aborting..."; exit; }
+    [ -z "$INSTALLMAN" ] && { echo "  Something with the manpages directory went wrong, aborting..."; exit; }
+    # Check if symlinks dir does not exist
+    if [ ! -d "$INSTALLBIN" ]; then
+        mkdir -p "$INSTALLBIN" && echo "  The binaries directory '$INSTALLBIN' did not exist, but I've created it!" || { echo "  The binaries directory '$INSTALLBIN' does not exist and I could not make it, trying with sudo..."; exec sudo "$0" "$@"; }
+    fi
+    # Check if manpages dir does not exist
+    if [ ! -d "$INSTALLMAN" ]; then
+        mkdir -p "$INSTALLMAN" && echo "  The manpages directory '$INSTALLMAN' did not exist, but I've created it!" || { echo "  The manpages directory '$INSTALLBIN' does not exist and I could not make it, trying with sudo..."; exec sudo "$0" "$@"; }
+    fi
+    # Check if prefix does not exist
+    if [ ! -d "$INSTALLPREFIX" ]; then
+        # Try to make the prefix, otherwise ask for sudo, otherwise abort
+        mkdir -p "$INSTALLPREFIX" && echo "  The prefix '$INSTALLPREFIX' did not exist, but I've created it!" || { [ "$UID" -eq 0 ] && { echo "  The prefix '$INSTALLPREFIX' does not exist and I could not make it, aborting..."; exit; } || { echo "  The prefix '$INSTALLPREFIX' does not exist and I could not make it, trying with sudo..."; exec sudo "$0" "$@"; } }
+    fi
+    # Check if prefix is writable, otherwise ask for sudo
+    if [ ! -w "$INSTALLPREFIX" ]; then
+        [ "$UID" -eq 0 ] && { echo "  The prefix '$INSTALLPREFIX' could not be accessed by the root user! Something went wrong, aborting..."; exit; }|| { echo "  You don't have the rights to write to '$INSTALLPREFIX', trying with sudo..."; exec sudo "$0" "$@"; }
+    fi
+    INSTALLDIR="$INSTALLPREFIX/pdf2archive"
+    mkdir -p "$INSTALLDIR" && echo "  Installing to '$INSTALLDIR':" || { "  Something went wrong, aborting..."; exit; }
+    #get_source_path
+    echo "    Removing the previous installation (if any)..."
+    rm -rf "$INSTALLDIR/*" && echo "    Previous installation correctly removed!" || { echo "    Something went wrong, aborting..."; exit; }
+    echo "    Copying files..."
+    { tar cf - ./pdf2archive ./verapdf ./manpages | ( cd "$INSTALLDIR" && tar xf - ) && { [ "${PIPESTATUS[0]}" == "0" ] || { echo "    Something went wrong, aborting..."; exit; } } } && echo "    Files copied!" || { echo "    Something went wrong, aborting..."; exit; }
+    echo "  Symlinking binaries in '$INSTALLBIN'..."
+    ln -fs "$INSTALLDIR/pdf2archive" "$INSTALLBIN/pdf2archive" || { echo "  Something went wrong, aborting..."; exit; }
+    echo "  Symlinking manpages in '$INSTALLMAN'..."
+    ln -fs "$INSTALLDIR/manpages/pdf2archive.1" "$INSTALLMAN/pdf2archive.1" && echo "  Installation finished!" || { echo "  Something went wrong, aborting..."; exit; }
+    echo "
+  You should now be able to run PDF2ARCHIVE just by using
+
+      pdf2archive
+
+  in your shell. If that's not the case, be sure to update your path via
+
+      echo 'export PATH=\"$INSTALLBIN:\$PATH\"' >> ~/.bash_profile
+
+  and restart your shell afterwards. The manual can be consulted via
+
+      man pdf2archive
+"
+}
+
+
+#=====# VERSION COMPARE #=====#
+# From http://lists.us.dell.com/pipermail/dkms-devel/2004-July/000142.html
+version_compare() {
+    [ "$1" == "$2" ] && return 10
+    ver1front=`echo $1 | cut -d "." -f -1`
+    ver1back=`echo $1 | cut -d "." -f 2-`
+    ver2front=`echo $2 | cut -d "." -f -1`
+    ver2back=`echo $2 | cut -d "." -f 2-`
+    if [ "$ver1front" != "$1" ] || [ "$ver2front" != "$2" ]; then
+        [ "$ver1front" -gt "$ver2front" ] && return 11
+        [ "$ver1front" -lt "$ver2front" ] && return 9
+        [ "$ver1front" == "$1" ] || [ -z "$ver1back" ] && ver1back=0
+        [ "$ver2front" == "$2" ] || [ -z "$ver2back" ] && ver2back=0
+        version_compare "$ver1back" "$ver2back"
+        return $?
+    else
+        [ "$1" -gt "$2" ] && return 11 || return 9
+    fi
+}
+
+
+#=====# DOWNLOAD LATEST VERSION FUNCTION #=====#
+download_latest() {
+    INSTALLTMPDIR="$1"
+    LATESTVERSION="$2"
+    INSTALLARCHIVE="$INSTALLTMPDIR/pdf2archive-v$LATESTVERSION.tar.gz"
+    echo "  Downloading the latest version to $INSTALLARCHIVE"
+    curl -sL "https://github.com/matteosecli/pdf2archive/archive/v$LATESTVERSION.tar.gz" > "$INSTALLARCHIVE" && echo "  Download completed." || { echo "  Something went wrong during the download process, aborting..."; exit; }
+    cd "$INSTALLTMPDIR"
+    echo "  Unzipping archive..."
+    tar -zxf "pdf2archive-v$LATESTVERSION.tar.gz" && echo "  Archive unzipped." || { echo "  Something went wrong during the extraction, aborting..."; exit; }
+}
+
+
+#=====# UPDATE FUNCTION #=====#
+update() {
+    if [ "$(which curl)" == "" ]; then
+        echo "  ERROR: curl binary not found!"
+        exit
+    fi
+    LATESTVERSION=$(curl -s "https://github.com/matteosecli/pdf2archive/releases/latest" | grep -o 'tag/[v.0-9]*' | awk -F/v '{print $2}')
+    [ -z "$LATESTVERSION" ] && { echo "  Could not determine the latest version! Check your internet connection."; exit; }
+    version_compare "$LATESTVERSION" "$VERSION"; versionExitCode=$?;
+    case $versionExitCode in
+        10)
+            echo "  Already up-to-date."
+            exit
+            ;;
+        11)
+            echo "  You are using PDF2ARCHIVE v$VERSION, but v$LATESTVERSION is available."
+            if [ "$(which pdf2archive)" == "" ] || [ "$1" == "local" ]; then
+                echo "  WARNING: Updating the current local version..."
+                INSTALLTMPDIR=$(mktemp -d)
+                get_source_path
+                download_latest "$INSTALLTMPDIR" "$LATESTVERSION"
+                echo "  Installing..."
+                cd "$INSTALLTMPDIR/pdf2archive-$LATESTVERSION"
+                { tar cf - . | ( cd "$SOURCEDIR" && tar xf - ) && { [ "${PIPESTATUS[0]}" == "0" ] || { echo "  Something went wrong, aborting..."; exit; } } } && echo "  Files copied!" || { echo "  Something went wrong, aborting..."; exit; }
+            else
+                echo "  Proceeding with the update..."
+                INSTALLTMPDIR=$(mktemp -d)
+                INSTALLPREFIX="$( get_source_path; cd "$SOURCEDIR/.." 2> /dev/null && pwd -P )"
+                download_latest "$INSTALLTMPDIR" "$LATESTVERSION"
+                echo "  Installing..."
+                cd "$INSTALLTMPDIR/pdf2archive-$LATESTVERSION"
+                chmod +x pdf2archive
+                ./pdf2archive --install="$INSTALLPREFIX"
+            fi
+            echo "  Cleaning up..."
+            rm -rf "$INSTALLTMPDIR/*" && echo "  Temporary files removed!" || { echo "  Something went wrong, aborting..."; exit; }
+            echo "  Update completed, you should now be able to run PDF2ARCHIVE v$LATESTVERSION."
+            exit
+            ;;
+        9)
+            echo "  Oh man, you're riding high! No need to downgrade."
+            exit
+            ;;
+        *)
+            echo "  Something went wrong! Aborting..."
+            exit
+            ;;
+    esac
 }
 
 
@@ -98,11 +295,6 @@ run() {
 }
 
 
-#=====# CHECKS #=====#
-if [ "$(which gs)" == "" ]; then
-    echo "  ERROR: Ghostscript is not installed or it's not in the path"
-    exit
-fi
 
 
 #=====# INPUT PARSER #=====#
@@ -122,6 +314,20 @@ while [ "$1" != "" ]; do
             echo $VERSION
             exit
             ;;
+        --install)
+            install "$VALUE"
+            exit
+            ;;
+        --update)
+            if [ "$VALUE" == "local" ] || [ "$VALUE" == "" ] ; then
+                update "$VALUE"
+                exit
+            else
+                echo "  ERROR: unknown update option '$VALUE'"
+                help
+                exit 1
+            fi
+            ;;
         --debug)
             DEBUG=true
             MSGOPTS=""
@@ -140,6 +346,9 @@ while [ "$1" != "" ]; do
                 help
                 exit 1
             fi
+            ;;
+        --gspath)
+            GSBIN="$VALUE"
             ;;
         --cleanmetadata)
             [ -z ${PDFTITLE+x} ] && PDFTITLE=""
@@ -171,7 +380,7 @@ while [ "$1" != "" ]; do
             fi
             VALIDATE=true
             ;;
-        *.pdf)
+        *)
             if [ "$INPUT" == "" ]; then
                 INPUT=$PARAM
             elif [ "$OUTPUT" == "" ]; then
@@ -182,21 +391,27 @@ while [ "$1" != "" ]; do
                 exit 1
             fi
             ;;
-        *)
-            echo "  ERROR: unknown parameter \"$PARAM\""
-            help
-            exit 1
-            ;;
+       #*)
+       #     echo "  ERROR: unknown parameter \"$PARAM\""
+       #     help
+       #     exit 1
+       #     ;;
     esac
     shift
 done
 
+#=====# CHECKS #=====#
+if [ "$(which $GSBIN)" == "" ]; then
+    echo "  ERROR: Ghostscript is not installed or it's not in the path"
+    exit
+fi
 
 #=====# SET UP ALL THE STUFF #=====#
 echo "=== Welcome to PDF2ARCHIVE ==="
 if [ "$OUTPUT" == "" ]; then
     OUTPUT="${INPUT%.pdf}-PDFA.pdf"
 fi
+get_source_path
 TMPFILE=$(mktemp)
 TMPDIR=$(mktemp -d)
 PSTMPFILE=$TMPDIR/PDFA_def.ps
@@ -232,7 +447,7 @@ quit
 #     use 'LC_CTYPE=C && LANG=C && echo "$METADUMP" ...' in the
 #     variable assignments; however, this produces bad PDF files.
 #
-METADUMP=$(gs -dNODISPLAY -q -sFile="$INPUT" $INFOTMPFILE | iconv -f utf-8 -t utf-8 -c)
+METADUMP=$($GSBIN -dNODISPLAY -q -sFile="$INPUT" $INFOTMPFILE | iconv -f utf-8 -t utf-8 -c)
 [ -z ${PDFTITLE+x} ] && PDFTITLE=$(echo "$METADUMP" | grep "__knowninfoTitle: " | sed "s/^__knowninfoTitle: //g")
 [ -z ${PDFAUTHOR+x} ] && PDFAUTHOR=$(echo "$METADUMP" | grep "__knowninfoAuthor: " | sed "s/^__knowninfoAuthor: //g")
 [ -z ${PDFSUBJECT+x} ] && PDFSUBJECT=$(echo "$METADUMP" | grep "__knowninfoSubject: " | sed "s/^__knowninfoSubject: //g")
@@ -255,7 +470,7 @@ fi
 #=====# PRINT DEBUG INFO #=====#
 if $DEBUG; then
     echo "  DEBUG: running PDF2ARCHIVE, version $VERSION"
-    echo "  DEBUG: using Ghostscript binary at $(which gs), version $(gs --version)"
+    echo "  DEBUG: using Ghostscript binary at $(which $GSBIN), version $($GSBIN --version)"
     echo "  DEBUG: the input file is '$INPUT'"
     echo "  DEBUG: the output file is '$OUTPUT'"
     echo "  DEBUG: the intermediate processing file is $TMPFILE"
@@ -335,22 +550,22 @@ echo -n -e "\\x00\\x00\\x02\\x30\\x41\\x44\\x42\\x45\\x02\\x10\\x00\\x00\\x6d\\x
 
 #=====# DO THE ACTUAL CONVERSION #=====#
 echo "  Compressing PDF & embedding fonts..."
-run gs $MSGOPTS \
+run $GSBIN $MSGOPTS \
     -dBATCH -dNOPAUSE -dNOOUTERSAVE \
     -dCompatibilityLevel=1.4 \
     -dEmbedAllFonts=true -dSubsetFonts=true \
     -dCompressFonts=true -dCompressPages=true \
-    -dUseCIEColor -sColorConversionStrategy=RGB \
+    -sColorConversionStrategy=RGB \
     -dDownsampleMonoImages=false -dDownsampleGrayImages=false -dDownsampleColorImages=false \
     -dAutoFilterColorImages=false -dAutoFilterGrayImages=false \
     -sDEVICE=pdfwrite \
     -sOutputFile=$TMPFILE $INPUT
 echo "  Converting to PDF/A-1B..."
-run gs $MSGOPTS \
+run $GSBIN $MSGOPTS \
     -dPDFA=1 -dBATCH -dNOPAUSE -dNOOUTERSAVE \
     $QUALITYOPTS \
     -dCompatibilityLevel=1.4 -dPDFACompatibilityPolicy=1 \
-    -dUseCIEColor -sProcessColorModel=DeviceRGB -sColorConversionStrategy=RGB \
+    -sProcessColorModel=DeviceRGB -sColorConversionStrategy=RGB \
     -sOutputICCProfile=$ICCTMPFILE \
     -sDEVICE=pdfwrite \
     -sOutputFile=$OUTPUT $TMPFILE $PSTMPFILE
@@ -362,7 +577,7 @@ echo "  Done, now ESSE3 is happy! ;)"
 #=====# VALIDATE THE RESULT #=====#
 if $VALIDATE; then
     echo "  Validating resulting file..."
-    echo "  $(./verapdf/verapdf $VERAMSGOPTS --extract --flavour 1b --format text $OUTPUT)"
+    echo "  $("$SOURCEDIR"./verapdf/verapdf $VERAMSGOPTS --extract --flavour 1b --format text $OUTPUT)"
 else
     echo "  Suggestion: validate the resulting PDF to be sure it's PDF/A-1B compliant."
 fi


### PR DESCRIPTION
Install & update + manpage (#10)
Made ghostscript path configurable
Do not rely on file extension for input and output files
Remove the use of -dUseCIEColor its deprecated

NOTE: The manpage has to be updated for 0.4 once the API is defined.